### PR TITLE
ElementBuilder and SimpleGui changes

### DIFF
--- a/src/main/java/eu/pb4/sgui/api/elements/AnimatedGuiElementBuilder.java
+++ b/src/main/java/eu/pb4/sgui/api/elements/AnimatedGuiElementBuilder.java
@@ -1,5 +1,6 @@
 package eu.pb4.sgui.api.elements;
 
+import com.mojang.authlib.GameProfile;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.Item;
@@ -7,8 +8,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtHelper;
 import net.minecraft.nbt.StringTag;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -17,14 +22,16 @@ import java.util.Map;
 
 public class AnimatedGuiElementBuilder implements GuiElementBuilderInterface {
     private Item item = Items.STONE;
+    private CompoundTag tag;
     private int count = 1;
     private Text name = null;
     private List<Text> lore = new ArrayList<>();
+    private int damage = -1;
     private GuiElement.ItemClickCallback callback = (index, type, action) -> {};
     private byte hideFlags = 0;
-    private Map<Enchantment, Integer> enchantments = new HashMap<>();
-    private int customModelData = -1;
-    private List<ItemStack> itemStacks = new ArrayList<>();
+    private final Map<Enchantment, Integer> enchantments = new HashMap<>();
+
+    private final List<ItemStack> itemStacks = new ArrayList<>();
     private int interval = 1;
     private boolean random = false;
 
@@ -40,66 +47,202 @@ public class AnimatedGuiElementBuilder implements GuiElementBuilderInterface {
         return this;
     }
 
+    public AnimatedGuiElementBuilder saveItemStack() {
+        this.itemStacks.add(asStack());
+
+        this.item = Items.STONE;
+        this.tag = null;
+        this.count = 1;
+        this.name = null;
+        this.lore = new ArrayList<>();
+        this.damage = -1;
+        this.hideFlags = 0;
+        this.enchantments.clear();
+
+        return this;
+    }
+
+    /**
+     * Sets the {@link Item} of the current {@link ItemStack}
+     *
+     * @param item the item to use
+     */
     public AnimatedGuiElementBuilder setItem(Item item) {
         this.item = item;
         return this;
     }
 
-    public AnimatedGuiElementBuilder setName(Text name) {
+    /**
+     * Sets the name of the current {@link ItemStack}
+     *
+     * @param name the name to use
+     */
+    public AnimatedGuiElementBuilder setName(MutableText name) {
         this.name = name;
         return this;
     }
 
+    /**
+     * Sets the number of items in the current {@link ItemStack}
+     *
+     * @param count the number of items
+     */
     public AnimatedGuiElementBuilder setCount(int count) {
         this.count = count;
         return this;
     }
 
-    public AnimatedGuiElementBuilder setCustomModelData(int value) {
-        this.customModelData = value;
-        return this;
-    }
-
+    /**
+     * Sets the lore of the current {@link ItemStack}
+     *
+     * @param lore a list of all the lore lines
+     */
     public AnimatedGuiElementBuilder setLore(List<Text> lore) {
         this.lore = lore;
         return this;
     }
 
+    /**
+     * Adds a line of lore to the current {@link ItemStack}
+     *
+     * @param lore the line to add
+     */
     public AnimatedGuiElementBuilder addLoreLine(Text lore) {
         this.lore.add(lore);
         return this;
     }
 
+    /**
+     * Set the damage of the current {@link ItemStack}
+     *
+     * @param damage the amount of durability the item is missing
+     */
+    public AnimatedGuiElementBuilder setDamage(int damage) {
+        this.damage = damage;
+        return this;
+    }
+
+    /**
+     * Set the {@link eu.pb4.sgui.api.elements.GuiElementInterface.ItemClickCallback} used inside GUIs
+     *
+     * @param callback the callback
+     */
     public AnimatedGuiElementBuilder setCallback(GuiElement.ItemClickCallback callback) {
         this.callback = callback;
         return this;
     }
 
+    /**
+     * Hide all {@link net.minecraft.item.ItemStack.TooltipSection}s from the current {@link ItemStack}s display
+     */
     public AnimatedGuiElementBuilder hideFlags() {
         this.hideFlags = 64;
         return this;
     }
 
+    /**
+     * Set the hide flags value for the current {@link ItemStack}s display
+     *
+     * @param value the flags to hide
+     */
     public AnimatedGuiElementBuilder hideFlags(byte value) {
         this.hideFlags = value;
         return this;
     }
 
+    /**
+     * Hide a {@link net.minecraft.item.ItemStack.TooltipSection}s from the current {@link ItemStack}s display
+     *
+     * @param section the section to hide
+     */
+    public AnimatedGuiElementBuilder hideFlag(ItemStack.TooltipSection section) {
+        this.hideFlags = (byte) (this.hideFlags | section.getFlag());
+        return this;
+    }
+
+    /**
+     * Give the current {@link ItemStack} the specified enchantment
+     *
+     * @param enchantment the {@link Enchantment} to apply
+     * @param level the level of the specified enchantment
+     */
     public AnimatedGuiElementBuilder enchant(Enchantment enchantment, int level) {
         this.enchantments.put(enchantment, level);
         return this;
     }
 
+    /**
+     * Sets the current {@link ItemStack} to have an enchantment glint
+     */
     public AnimatedGuiElementBuilder glow() {
         this.enchantments.put(Enchantments.LUCK_OF_THE_SEA, 1);
-        this.hideFlags = (byte) (this.hideFlags | 0x01);
+        return hideFlag(ItemStack.TooltipSection.ENCHANTMENTS);
+    }
+
+    /**
+     * Sets the custom model data of the current {@link ItemStack}
+     *
+     * @param value the value used for custom model data
+     */
+    public AnimatedGuiElementBuilder setCustomModelData(int value) {
+        this.getOrCreateTag().putInt("CustomModelData", value);
         return this;
     }
 
-    public AnimatedGuiElementBuilder saveItemStack() {
+    /**
+     * Sets the current {@link ItemStack} to be unbreakable, also hiding the durability bar.
+     */
+    public AnimatedGuiElementBuilder unbreakable() {
+        this.getOrCreateTag().putBoolean("Unbreakable", true);
+        return hideFlag(ItemStack.TooltipSection.UNBREAKABLE);
+    }
+
+    /**
+     * Sets the skull owner tag of a player head.
+     * If the server parameter is not supplied it may lag the client while it loads the texture,
+     * otherwise if the server is provided and the {@link GameProfile} contains a UUID then the textures will be loaded by the server.
+     * This can take some time the first load, however the skins are cached for later uses.
+     *
+     * @param profile the {@link GameProfile} of the owner
+     * @param server the server instance, used to get the textures
+     */
+    public AnimatedGuiElementBuilder setSkullOwner(GameProfile profile, @Nullable MinecraftServer server) {
+        if (profile.getId() != null && server != null) {
+            profile = server.getSessionService().fillProfileProperties(profile, false);
+            this.getOrCreateTag().put("SkullOwner", NbtHelper.fromGameProfile(new CompoundTag(), profile));
+        } else {
+            this.getOrCreateTag().putString("SkullOwner", profile.getName());
+        }
+        return this;
+    }
+
+    private CompoundTag getOrCreateTag() {
+        if (this.tag == null) {
+            this.tag = new CompoundTag();
+        }
+        return this.tag;
+    }
+
+    public AnimatedGuiElement build() {
+        return new AnimatedGuiElement(this.itemStacks.toArray(new ItemStack[0]), this.interval, this.random, this.callback);
+    }
+
+    public ItemStack asStack() {
         ItemStack itemStack = new ItemStack(this.item, this.count);
+
+        if (this.tag != null) {
+            itemStack.getOrCreateTag().copyFrom(this.tag);
+        }
+
         if (this.name != null) {
+            if (this.name instanceof MutableText) {
+                ((MutableText) this.name).styled(style -> style.withItalic(style.isItalic()));
+            }
             itemStack.setCustomName(this.name);
+        }
+
+        if (this.item.isDamageable() && this.damage != -1) {
+            itemStack.setDamage(damage);
         }
 
         for (Map.Entry<Enchantment, Integer> entry : this.enchantments.entrySet()) {
@@ -110,29 +253,18 @@ public class AnimatedGuiElementBuilder implements GuiElementBuilderInterface {
             CompoundTag display = itemStack.getOrCreateSubTag("display");
             ListTag loreItems = new ListTag();
             for (Text l : this.lore) {
+                if (l instanceof MutableText) {
+                    ((MutableText) l).styled(style -> style.withItalic(style.isItalic()));
+                }
                 loreItems.add(StringTag.of(Text.Serializer.toJson(l)));
             }
             display.put("Lore", loreItems);
         }
 
-        itemStack.getOrCreateTag().putByte("HideFlags", this.hideFlags);
-        if (this.customModelData != -1) {
-            itemStack.getOrCreateTag().putInt("CustomModelData", this.customModelData);
+        if (this.hideFlags != 0) {
+            itemStack.getOrCreateTag().putByte("HideFlags", this.hideFlags);
         }
 
-        this.itemStacks.add(itemStack);
-
-        this.item = Items.STONE;
-        this.count = 1;
-        this.name = null;
-        this.lore = new ArrayList<>();
-        this.hideFlags = 0;
-        this.enchantments = new HashMap<>();
-        this.customModelData = -1;
-        return this;
-    }
-
-    public AnimatedGuiElement build() {
-        return new AnimatedGuiElement(this.itemStacks.toArray(new ItemStack[0]), this.interval, this.random, this.callback);
+        return itemStack;
     }
 }

--- a/src/main/java/eu/pb4/sgui/api/elements/GuiElementBuilder.java
+++ b/src/main/java/eu/pb4/sgui/api/elements/GuiElementBuilder.java
@@ -1,5 +1,7 @@
 package eu.pb4.sgui.api.elements;
 
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.Item;
@@ -7,20 +9,26 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtHelper;
 import net.minecraft.nbt.StringTag;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerTask;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
 public class GuiElementBuilder implements GuiElementBuilderInterface {
     private Item item = Items.STONE;
+    private CompoundTag tag;
     private int count = 1;
-    private Text name = null;
-    private List<Text> lore = new ArrayList<>();
+    private MutableText name = null;
+    private List<MutableText> lore = new ArrayList<>();
+    private int damage = -1;
     private GuiElement.ItemClickCallback callback = (index, type, action) -> {};
     private byte hideFlags = 0;
-    private Map<Enchantment, Integer> enchantments = new HashMap<>();
-    private int customModelData = -1;
+    private final Map<Enchantment, Integer> enchantments = new HashMap<>();
 
     public GuiElementBuilder() {}
 
@@ -33,66 +41,184 @@ public class GuiElementBuilder implements GuiElementBuilderInterface {
         this.item = item;
     }
 
+    /**
+     * Sets the {@link Item} of the {@link ItemStack}
+     *
+     * @param item the item to use
+     */
     public GuiElementBuilder setItem(Item item) {
         this.item = item;
         return this;
     }
 
-    public GuiElementBuilder setName(Text name) {
+    /**
+     * Sets the name of the {@link ItemStack}
+     *
+     * @param name the name to use
+     */
+    public GuiElementBuilder setName(MutableText name) {
         this.name = name;
         return this;
     }
 
+    /**
+     * Sets the number of items in the {@link ItemStack}
+     *
+     * @param count the number of items
+     */
     public GuiElementBuilder setCount(int count) {
         this.count = count;
         return this;
     }
 
-    public GuiElementBuilder setCustomModelData(int value) {
-        this.customModelData = value;
-        return this;
-    }
-
-    public GuiElementBuilder setLore(List<Text> lore) {
+    /**
+     * Sets the lore of the {@link ItemStack}
+     *
+     * @param lore a list of all the lore lines
+     */
+    public GuiElementBuilder setLore(List<MutableText> lore) {
         this.lore = lore;
         return this;
     }
 
-    public GuiElementBuilder addLoreLine(Text lore) {
+    /**
+     * Adds a line of lore to the {@link ItemStack}
+     *
+     * @param lore the line to add
+     */
+    public GuiElementBuilder addLoreLine(MutableText lore) {
         this.lore.add(lore);
         return this;
     }
 
+    /**
+     * Set the damage of the {@link ItemStack}
+     *
+     * @param damage the amount of durability the item is missing
+     */
+    public GuiElementBuilder setDamage(int damage) {
+        this.damage = damage;
+        return this;
+    }
+
+    /**
+     * Set the {@link eu.pb4.sgui.api.elements.GuiElementInterface.ItemClickCallback} used inside GUIs
+     *
+     * @param callback the callback
+     */
     public GuiElementBuilder setCallback(GuiElement.ItemClickCallback callback) {
         this.callback = callback;
         return this;
     }
 
+    /**
+     * Hide all {@link net.minecraft.item.ItemStack.TooltipSection}s from the {@link ItemStack}s display
+     */
     public GuiElementBuilder hideFlags() {
         this.hideFlags = 64;
         return this;
     }
 
+    /**
+     * Set the hide flags value for the {@link ItemStack}s display
+     *
+     * @param value the flags to hide
+     */
     public GuiElementBuilder hideFlags(byte value) {
         this.hideFlags = value;
         return this;
     }
 
+    /**
+     * Hide a {@link net.minecraft.item.ItemStack.TooltipSection}s from the {@link ItemStack}s display
+     *
+     * @param section the section to hide
+     */
+    public GuiElementBuilder hideFlag(ItemStack.TooltipSection section) {
+        this.hideFlags = (byte) (this.hideFlags | section.getFlag());
+        return this;
+    }
+
+    /**
+     * Give the {@link ItemStack} the specified enchantment
+     *
+     * @param enchantment the {@link Enchantment} to apply
+     * @param level the level of the specified enchantment
+     */
     public GuiElementBuilder enchant(Enchantment enchantment, int level) {
         this.enchantments.put(enchantment, level);
         return this;
     }
 
+    /**
+     * Sets the {@link ItemStack} to have an enchantment glint
+     */
     public GuiElementBuilder glow() {
         this.enchantments.put(Enchantments.LUCK_OF_THE_SEA, 1);
-        this.hideFlags = (byte) (this.hideFlags | 0x01);
+        return hideFlag(ItemStack.TooltipSection.ENCHANTMENTS);
+    }
+
+    /**
+     * Sets the custom model data of the {@link ItemStack}
+     *
+     * @param value the value used for custom model data
+     */
+    public GuiElementBuilder setCustomModelData(int value) {
+        this.getOrCreateTag().putInt("CustomModelData", value);
         return this;
     }
 
+    /**
+     * Sets the {@link ItemStack} to be unbreakable, also hiding the durability bar.
+     */
+    public GuiElementBuilder unbreakable() {
+        this.getOrCreateTag().putBoolean("Unbreakable", true);
+        return hideFlag(ItemStack.TooltipSection.UNBREAKABLE);
+    }
+
+    /**
+     * Sets the skull owner tag of a player head.
+     * If the server parameter is not supplied it may lag the client while it loads the texture,
+     * otherwise if the server is provided and the {@link GameProfile} contains a UUID then the textures will be loaded by the server.
+     * This can take some time the first load, however the skins are cached for later uses.
+     *
+     * @param profile the {@link GameProfile} of the owner
+     * @param server the server instance, used to get the textures
+     */
+    public GuiElementBuilder setSkullOwner(GameProfile profile, @Nullable MinecraftServer server) {
+        if (profile.getId() != null && server != null) {
+            profile = server.getSessionService().fillProfileProperties(profile, false);
+            this.getOrCreateTag().put("SkullOwner", NbtHelper.fromGameProfile(new CompoundTag(), profile));
+        } else {
+            this.getOrCreateTag().putString("SkullOwner", profile.getName());
+        }
+        return this;
+    }
+
+    private CompoundTag getOrCreateTag() {
+        if (this.tag == null) {
+            this.tag = new CompoundTag();
+        }
+        return this.tag;
+    }
+
     public GuiElement build() {
+        return new GuiElement(asStack(), this.callback);
+    }
+
+    public ItemStack asStack() {
         ItemStack itemStack = new ItemStack(this.item, this.count);
+
+        if (this.tag != null) {
+            itemStack.getOrCreateTag().copyFrom(this.tag);
+        }
+
         if (this.name != null) {
-            itemStack.setCustomName(this.name);
+            itemStack.setCustomName(this.name.styled(style -> style.withItalic(style.isItalic())));
+        }
+
+        if (this.item.isDamageable() && this.damage != -1) {
+            itemStack.setDamage(damage);
         }
 
         for (Map.Entry<Enchantment, Integer> entry : this.enchantments.entrySet()) {
@@ -102,17 +228,17 @@ public class GuiElementBuilder implements GuiElementBuilderInterface {
         if (this.lore.size() > 0) {
             CompoundTag display = itemStack.getOrCreateSubTag("display");
             ListTag loreItems = new ListTag();
-            for (Text l : this.lore) {
-                loreItems.add(StringTag.of(Text.Serializer.toJson(l)));
+            for (MutableText l : this.lore) {
+                loreItems.add(StringTag.of(Text.Serializer.toJson(l.styled(style -> style.withItalic(style.isItalic())))));
             }
             display.put("Lore", loreItems);
         }
 
-        itemStack.getOrCreateTag().putByte("HideFlags", this.hideFlags);
-        if (this.customModelData != -1) {
-            itemStack.getOrCreateTag().putInt("CustomModelData", this.customModelData);
+        if (this.hideFlags != 0) {
+            itemStack.getOrCreateTag().putByte("HideFlags", this.hideFlags);
         }
 
-        return new GuiElement(itemStack, this.callback);
+        return itemStack;
     }
+
 }

--- a/src/main/java/eu/pb4/sgui/api/elements/GuiElementBuilder.java
+++ b/src/main/java/eu/pb4/sgui/api/elements/GuiElementBuilder.java
@@ -1,7 +1,6 @@
 package eu.pb4.sgui.api.elements;
 
 import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.Item;
@@ -12,19 +11,21 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtHelper;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.ServerTask;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class GuiElementBuilder implements GuiElementBuilderInterface {
     private Item item = Items.STONE;
     private CompoundTag tag;
     private int count = 1;
-    private MutableText name = null;
-    private List<MutableText> lore = new ArrayList<>();
+    private Text name = null;
+    private List<Text> lore = new ArrayList<>();
     private int damage = -1;
     private GuiElement.ItemClickCallback callback = (index, type, action) -> {};
     private byte hideFlags = 0;
@@ -76,7 +77,7 @@ public class GuiElementBuilder implements GuiElementBuilderInterface {
      *
      * @param lore a list of all the lore lines
      */
-    public GuiElementBuilder setLore(List<MutableText> lore) {
+    public GuiElementBuilder setLore(List<Text> lore) {
         this.lore = lore;
         return this;
     }
@@ -86,7 +87,7 @@ public class GuiElementBuilder implements GuiElementBuilderInterface {
      *
      * @param lore the line to add
      */
-    public GuiElementBuilder addLoreLine(MutableText lore) {
+    public GuiElementBuilder addLoreLine(Text lore) {
         this.lore.add(lore);
         return this;
     }
@@ -214,7 +215,10 @@ public class GuiElementBuilder implements GuiElementBuilderInterface {
         }
 
         if (this.name != null) {
-            itemStack.setCustomName(this.name.styled(style -> style.withItalic(style.isItalic())));
+            if (this.name instanceof MutableText) {
+                ((MutableText) this.name).styled(style -> style.withItalic(style.isItalic()));
+            }
+            itemStack.setCustomName(this.name);
         }
 
         if (this.item.isDamageable() && this.damage != -1) {
@@ -228,8 +232,11 @@ public class GuiElementBuilder implements GuiElementBuilderInterface {
         if (this.lore.size() > 0) {
             CompoundTag display = itemStack.getOrCreateSubTag("display");
             ListTag loreItems = new ListTag();
-            for (MutableText l : this.lore) {
-                loreItems.add(StringTag.of(Text.Serializer.toJson(l.styled(style -> style.withItalic(style.isItalic())))));
+            for (Text l : this.lore) {
+                if (l instanceof MutableText) {
+                    ((MutableText) l).styled(style -> style.withItalic(style.isItalic()));
+                }
+                loreItems.add(StringTag.of(Text.Serializer.toJson(l)));
             }
             display.put("Lore", loreItems);
         }

--- a/src/main/java/eu/pb4/sgui/api/gui/BookGui.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/BookGui.java
@@ -70,7 +70,6 @@ public class BookGui implements GuiInterface {
         this.close(false);
     }
 
-
     @Deprecated
     public void close(boolean screenHandlerIsClosed) {
         if (this.open && !this.reOpen) {
@@ -108,6 +107,8 @@ public class BookGui implements GuiInterface {
     public void onUpdate(boolean firstUpdate) {}
 
     public void onClose() {}
+
+    public void onTick() {}
 
     public ItemStack getBook() {
         return this.book;

--- a/src/main/java/eu/pb4/sgui/api/gui/SimpleGui.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/SimpleGui.java
@@ -187,6 +187,57 @@ public class SimpleGui implements GuiInterface {
     }
 
     /**
+     * Sets the first open slot with selected GuiElement
+     *
+     * @param element Any GuiElement
+     */
+    public void addSlot(GuiElementInterface element) {
+        this.setSlot(getFirstEmptySlot(), element);
+    }
+
+    /**
+     * Sets the first open slot with selected ItemStack
+     *
+     * @param itemStack Stack of Items
+     */
+    public void addSlot(ItemStack itemStack) {
+        this.setSlot(getFirstEmptySlot(), itemStack);
+    }
+
+    /**
+     * Sets the first open slot with selected GuiElement created from builder
+     *
+     * @param element Any GuiElementBuilder
+     */
+    public void addSlot(GuiElementBuilderInterface element) {
+        this.setSlot(getFirstEmptySlot(), element.build());
+    }
+
+    /**
+     * Sets the first open slot with ItemStack and Callback
+     *
+     * @param itemStack Stack of Items
+     * @param callback Callback run when clicked
+     */
+    public void addSlot(ItemStack itemStack, GuiElement.ItemClickCallback callback) {
+        this.setSlot(getFirstEmptySlot(), new GuiElement(itemStack, callback));
+    }
+
+    /**
+     * Gets the first empty slot inside the inventory.
+     *
+     * @return the slots index or the last slot if full
+     */
+    public int getFirstEmptySlot() {
+        for (int i = 0; i < elements.length; i++) {
+            if (elements[i] == null) {
+                return i;
+            }
+        }
+        return elements.length - 1;
+    }
+
+    /**
      * Allows to add own Slot instances, that can point to any inventory
      * Do not add duplicates (including player inventory)
      * as it can cause item duplication!

--- a/src/main/java/eu/pb4/sgui/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/eu/pb4/sgui/mixin/ServerPlayNetworkHandlerMixin.java
@@ -1,11 +1,14 @@
 package eu.pb4.sgui.mixin;
 
-import eu.pb4.sgui.api.gui.AnvilInputGui;
 import eu.pb4.sgui.api.ClickType;
+import eu.pb4.sgui.api.gui.AnvilInputGui;
 import eu.pb4.sgui.virtual.BookScreenHandler;
 import eu.pb4.sgui.virtual.VirtualScreenHandler;
 import net.minecraft.network.Packet;
-import net.minecraft.network.packet.c2s.play.*;
+import net.minecraft.network.packet.c2s.play.ClickSlotC2SPacket;
+import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket;
+import net.minecraft.network.packet.c2s.play.CraftRequestC2SPacket;
+import net.minecraft.network.packet.c2s.play.RenameItemC2SPacket;
 import net.minecraft.network.packet.s2c.play.ConfirmScreenActionS2CPacket;
 import net.minecraft.network.packet.s2c.play.InventoryS2CPacket;
 import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;

--- a/src/main/java/eu/pb4/sgui/virtual/BookScreenHandler.java
+++ b/src/main/java/eu/pb4/sgui/virtual/BookScreenHandler.java
@@ -55,6 +55,7 @@ public class BookScreenHandler extends ScreenHandler {
 
     @Override
     public void sendContentUpdates() {
+        gui.onTick();
         super.sendContentUpdates();
     }
 

--- a/src/main/java/eu/pb4/sgui/virtual/BookScreenHandler.java
+++ b/src/main/java/eu/pb4/sgui/virtual/BookScreenHandler.java
@@ -1,7 +1,6 @@
 package eu.pb4.sgui.virtual;
 
 import eu.pb4.sgui.api.gui.BookGui;
-import eu.pb4.sgui.api.gui.SimpleGui;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
@@ -59,7 +58,7 @@ public class BookScreenHandler extends ScreenHandler {
         super.sendContentUpdates();
     }
 
-        @Override
+    @Override
     public ItemStack transferSlot(PlayerEntity player, int index) {
         return ItemStack.EMPTY;
     }

--- a/src/main/java/eu/pb4/sgui/virtual/BookScreenHandlerFactory.java
+++ b/src/main/java/eu/pb4/sgui/virtual/BookScreenHandlerFactory.java
@@ -1,7 +1,6 @@
 package eu.pb4.sgui.virtual;
 
 import eu.pb4.sgui.api.gui.BookGui;
-import eu.pb4.sgui.api.gui.SimpleGui;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.screen.NamedScreenHandlerFactory;

--- a/src/testmod/java/eu/pb4/sgui/testmod/SGuiTest.java
+++ b/src/testmod/java/eu/pb4/sgui/testmod/SGuiTest.java
@@ -175,7 +175,7 @@ public class SGuiTest implements ModInitializer {
             ServerPlayerEntity player = objectCommandContext.getSource().getPlayer();
             BookGui gui = new BookGui(player, player.getMainHandStack());
             gui.open();
-            
+
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/testmod/java/eu/pb4/sgui/testmod/SGuiTest.java
+++ b/src/testmod/java/eu/pb4/sgui/testmod/SGuiTest.java
@@ -1,5 +1,6 @@
 package eu.pb4.sgui.testmod;
 
+import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.context.CommandContext;
 import eu.pb4.sgui.api.ClickType;
 import eu.pb4.sgui.api.elements.*;
@@ -19,6 +20,8 @@ import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
+
+import java.util.UUID;
 
 import static net.minecraft.server.command.CommandManager.literal;
 
@@ -68,9 +71,9 @@ public class SGuiTest implements ModInitializer {
             }, 10, false, (x, y, z) -> {}));
 
             gui.setSlot(2, new AnimatedGuiElementBuilder()
-                    .setItem(Items.NETHERITE_AXE).saveItemStack()
-                    .setItem(Items.DIAMOND_AXE).saveItemStack()
-                    .setItem(Items.GOLDEN_AXE).saveItemStack()
+                    .setItem(Items.NETHERITE_AXE).setDamage(150).saveItemStack()
+                    .setItem(Items.DIAMOND_AXE).setDamage(150).unbreakable().saveItemStack()
+                    .setItem(Items.GOLDEN_AXE).glow().saveItemStack()
                     .setItem(Items.IRON_AXE).saveItemStack()
                     .setItem(Items.STONE_AXE).saveItemStack()
                     .setItem(Items.WOODEN_AXE).saveItemStack()
@@ -82,6 +85,12 @@ public class SGuiTest implements ModInitializer {
                 itemStack.setCount(x);
                 gui.setSlot(x, new GuiElement(itemStack, (index, clickType, actionType) -> {}));
             }
+
+            gui.setSlot(6, new GuiElementBuilder(Items.PLAYER_HEAD)
+                    .setSkullOwner(new GameProfile(UUID.fromString("f5a216d9-d660-4996-8d0f-d49053677676"), "patbox"), player.server)
+                    .setName(new LiteralText("Patbox's Head"))
+                    .glow()
+            );
 
             gui.setSlot(7, new GuiElementBuilder()
                     .setItem(Items.BARRIER)
@@ -166,7 +175,7 @@ public class SGuiTest implements ModInitializer {
             ServerPlayerEntity player = objectCommandContext.getSource().getPlayer();
             BookGui gui = new BookGui(player, player.getMainHandStack());
             gui.open();
-
+            
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -218,4 +227,5 @@ public class SGuiTest implements ModInitializer {
         }
         return 0;
     }
+
 }


### PR DESCRIPTION
This pull request has 2 main components:

- Adding the addSlot methods to SimpleGui
  - These will put the elements in the first open slot found.
- Adding some extra options and documentation to GuiElementBuilder
  - This invloved some reworking of some things such as moving CustomModelData and some new options to be placed into a CompoundTag rather than there own specific variables.
  - Added the unbreakable method
  - Added the setDamage method
  - Added methods for hiding tags by referencing the TooltipSection rather than the flag implicitly
  - Moved the name and lore to MutableText from Text so we can force the client to not render them as italic unless they are actually set to italic.
  - Added the ability to set a SkullOwner for items, this takes a game profile and a server, however this is not required (see javadoc)
  - Moved the ItemStack creation to a separate method so it can be utilised elsewhere