### PR TITLE
Use UUID instead of ServerPlayerEntity for storage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ fabric_version=0.42.8+1.18
 
 
 # Mod Properties
-	mod_version = 1.0.0-rc6+1.18-pre5
+	mod_version = 1.0.0-rc6+1.18-pre6
 	maven_group = eu.pb4
 	archives_base_name = sgui
 

--- a/src/main/java/eu/pb4/sgui/api/gui/AnvilInputGui.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/AnvilInputGui.java
@@ -83,6 +83,6 @@ public class AnvilInputGui extends SimpleGui {
         if (element != null) {
             stack = element.getItemStack();
         }
-        GuiHelpers.sendSlotUpdate(player, this.syncId, 2, stack);
+        GuiHelpers.sendSlotUpdate(getPlayer(), this.syncId, 2, stack);
     }
 }

--- a/src/main/java/eu/pb4/sgui/api/gui/BaseSlotGui.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/BaseSlotGui.java
@@ -1,13 +1,16 @@
 package eu.pb4.sgui.api.gui;
 
 import eu.pb4.sgui.api.elements.GuiElementInterface;
-import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.Slot;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
-import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
 
 public abstract class BaseSlotGui implements SlotGuiInterface {
-    protected final ServerPlayerEntity player;
+    protected final UUID uuid;
+    protected final MinecraftServer server;
     protected final GuiElementInterface[] elements;
     protected final Slot[] slotRedirects;
     protected boolean open = false;
@@ -17,7 +20,8 @@ public abstract class BaseSlotGui implements SlotGuiInterface {
 
 
     public BaseSlotGui(ServerPlayerEntity player, int size) {
-        this.player = player;
+        this.uuid = player.getUuid();
+        this.server = player.getServer();
         this.elements = new GuiElementInterface[size];
         this.slotRedirects = new Slot[size];
         this.size = size;
@@ -97,8 +101,8 @@ public abstract class BaseSlotGui implements SlotGuiInterface {
         return this.size;
     }
 
-    @Override
+    @Override @Nullable
     public ServerPlayerEntity getPlayer() {
-        return this.player;
+        return server.getPlayerManager().getPlayer(uuid);
     }
 }

--- a/src/main/java/eu/pb4/sgui/api/gui/MerchantGui.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/MerchantGui.java
@@ -196,17 +196,23 @@ public class MerchantGui extends SimpleGui {
     public void sendUpdate() {
         TradeOfferList tradeOfferList = this.merchant.getOffers();
         if (!tradeOfferList.isEmpty()) {
-            player.sendTradeOffers(this.syncId, tradeOfferList, this.merchant.getLevel(), this.merchant.getExperience(), this.merchant.isLeveledMerchant(), this.merchant.canRefreshTrades());
+            ServerPlayerEntity player = this.getPlayer();
+            if (player != null) {
+                player.sendTradeOffers(this.syncId, tradeOfferList, this.merchant.getLevel(), this.merchant.getExperience(), this.merchant.isLeveledMerchant(), this.merchant.canRefreshTrades());
+            }
         }
     }
 
     @Override
     protected boolean sendGui() {
         this.reOpen = true;
-        OptionalInt opSyncId = player.openHandledScreen(new SimpleNamedScreenHandlerFactory((syncId, playerInventory, playerx) -> new VirtualMerchantScreenHandler(syncId, this.player, this.merchant, this, this.merchantInventory), this.getTitle()));
+        ServerPlayerEntity player = this.getPlayer();
+        if (player == null) return false;
+
+        OptionalInt opSyncId = player.openHandledScreen(new SimpleNamedScreenHandlerFactory((syncId, playerInventory, playerx) -> new VirtualMerchantScreenHandler(syncId, player, this.merchant, this, this.merchantInventory), this.getTitle()));
         if (opSyncId.isPresent()) {
             this.syncId = opSyncId.getAsInt();
-            this.screenHandler = (VirtualMerchantScreenHandler) this.player.currentScreenHandler;
+            this.screenHandler = (VirtualMerchantScreenHandler) player.currentScreenHandler;
 
             TradeOfferList tradeOfferList = this.merchant.getOffers();
             if (!tradeOfferList.isEmpty()) {

--- a/src/main/java/eu/pb4/sgui/virtual/book/BookScreenHandler.java
+++ b/src/main/java/eu/pb4/sgui/virtual/book/BookScreenHandler.java
@@ -2,10 +2,8 @@ package eu.pb4.sgui.virtual.book;
 
 import eu.pb4.sgui.api.gui.BookGui;
 import eu.pb4.sgui.virtual.VirtualScreenHandlerInterface;
-import eu.pb4.sgui.virtual.inventory.VirtualInventory;
 import eu.pb4.sgui.virtual.inventory.VirtualSlot;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;

--- a/src/testmod/java/eu/pb4/sgui/testmod/SGuiTest.java
+++ b/src/testmod/java/eu/pb4/sgui/testmod/SGuiTest.java
@@ -47,7 +47,7 @@ public class SGuiTest implements ModInitializer {
             SimpleGui gui = new SimpleGui(ScreenHandlerType.GENERIC_3X3, player, false) {
                 @Override
                 public boolean onClick(int index, ClickType type, SlotActionType action, GuiElementInterface element) {
-                    this.player.sendMessage(new LiteralText(type.toString()), false);
+                    player.sendMessage(new LiteralText(type.toString()), false);
 
                     return super.onClick(index, type, action, element);
                 }
@@ -252,7 +252,7 @@ public class SGuiTest implements ModInitializer {
                 @Override
                 public void onCraftRequest(Identifier recipeId, boolean shift) {
                     super.onCraftRequest(recipeId, shift);
-                    this.player.sendMessage(new LiteralText(recipeId.toString() + " - " + shift), false);
+                    player.sendMessage(new LiteralText(recipeId.toString() + " - " + shift), false);
                 }
             };
 
@@ -312,7 +312,7 @@ public class SGuiTest implements ModInitializer {
 
                 @Override
                 public void onSelectTrade(TradeOffer offer) {
-                    this.player.sendMessage(new LiteralText("Selected Trade: " + this.getOfferIndex(offer)), false);
+                    player.sendMessage(new LiteralText("Selected Trade: " + this.getOfferIndex(offer)), false);
                 }
 
                 @Override


### PR DESCRIPTION
(This commit might miss a few things as I'm not familiar with the current codebase.)

(There should be no changes on the API layer other than getPlayer() being nullable.)

ServerPlayerEntity is volatile and is useless even just after player death, this PR supposedly fixes this issue I was having with the lib. (Which is "stored GUI being inaccessible after player death/relog")