### PR TITLE
Check slot's max item count when inserting items into a VirtualScreenHandler

### DIFF
--- a/src/main/java/eu/pb4/sgui/virtual/inventory/VirtualScreenHandler.java
+++ b/src/main/java/eu/pb4/sgui/virtual/inventory/VirtualScreenHandler.java
@@ -153,14 +153,15 @@ public class VirtualScreenHandler extends ScreenHandler implements VirtualScreen
 
                 if (!(slot2 instanceof VirtualSlot) && stack != itemStack && !itemStack.isEmpty() && ItemStack.canCombine(stack, itemStack)) {
                     int j = itemStack.getCount() + stack.getCount();
-                    if (j <= stack.getMaxCount()) {
+                    int max = Math.min(slot2.getMaxItemCount(), stack.getMaxCount());
+                    if (j <= max) {
                         stack.setCount(0);
                         itemStack.setCount(j);
                         slot2.markDirty();
                         bl = true;
-                    } else if (itemStack.getCount() < stack.getMaxCount()) {
-                        stack.decrement(stack.getMaxCount() - itemStack.getCount());
-                        itemStack.setCount(stack.getMaxCount());
+                    } else if (itemStack.getCount() < max) {
+                        stack.decrement(max - itemStack.getCount());
+                        itemStack.setCount(max);
                         slot2.markDirty();
                         bl = true;
                     }


### PR DESCRIPTION
VirtualScreenHandler's [insertItem()](https://github.com/Patbox/sgui/blob/5af27719c8add01e9eb9d894fefa62f03f469035/src/main/java/eu/pb4/sgui/virtual/inventory/VirtualScreenHandler.java#L131) method loops through all slots of the gui and attempts to merge the ItemStack with the slot. It correctly compares the items and their max stack sizes, but it does not take in to account the max item count of the Slot itself. This means that when shift-clicking items into a gui, items can be stacked to their default stack size even in slots that are meant to contain less items. This issue makes it basically impossible to properly create a GUI with slots that, for example, only contain 1 of a stackable item.
This pull request fixes this by calculating the maximum items that should be put into the slot from the minimum of `Slot.getMaxItemCount` and `ItemStack.getMaxCount`, and then using that value in the comparisons instead of just the ItemStack's max count.
I have tested this with the included testmod, but I did not include those changes in this pull request (I overrode the Slot that was linked to the ender chest, and it just made that example more confusing).