### PR TITLE
Fix cyclical packets with HotbarGui#onSelectedSlotChange

### DIFF
--- a/src/main/java/eu/pb4/sgui/api/gui/HotbarGui.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/HotbarGui.java
@@ -136,11 +136,11 @@ public class HotbarGui extends BaseSlotGui {
     /**
      * It's run after player changes selected slot. It can also block switching by returning false
      *
-     * @param slot new selected slot
+     * @param slot the newly selected slot
      * @return true to allow or false for canceling switching
      */
     public boolean onSelectedSlotChange(int slot) {
-        this.setSelectedSlot(slot);
+        this.selectedSlot = MathHelper.clamp(slot, 0, 8);
         return true;
     }
 


### PR DESCRIPTION
When a player selects a slot when using the HotbarGui the HotbarGui would send the client back a packet, when scrolling this would cause the client and server to be stuck in an endless loop of trying to sync each other up.

This fixes the issue by not sending the client the packet when they update the slot on the server.

Unsure about the api implementation, the method should probably be marked with `@OverrideOnly` or `@Internal` with a separate protected method provided, to avoid people accidentally calling `onSelectedSlotChange` instead of `setSelectedSlot`