### PR TITLE
Fix ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/eu/pb4/sgui/api/gui/HotbarGui.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/HotbarGui.java
@@ -101,7 +101,10 @@ public class HotbarGui extends BaseSlotGui {
 
     @Override
     public boolean click(int index, ClickType type, SlotActionType action) {
-        return super.click(VANILLA_TO_GUI_IDS[index], type, action);
+        if (index >= 0 && index < SIZE) {
+            return super.click(VANILLA_TO_GUI_IDS[index], type, action);
+        }
+        return super.click(index, type, action);
     }
 
     @Override


### PR DESCRIPTION
Fixes an issue where if the player clicks outside their inventory an ArrayIndexOutOfBoundsException is thrown as `-999` is not a valid index.