### PR TITLE
Fixes #37

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.21-pre2
-yarn_mappings=1.21-pre2+build.2
-loader_version=0.15.11
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
+loader_version=0.16.5
 
 # Fabric API
-fabric_version=0.99.4+1.21
+fabric_version=0.105.0+1.21.1
 
 
 # Mod Properties

--- a/src/main/java/eu/pb4/sgui/api/gui/HotbarGui.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/HotbarGui.java
@@ -108,6 +108,17 @@ public class HotbarGui extends BaseSlotGui {
     }
 
     @Override
+    public int getHotbarSlotIndex(int index) {
+        // We add the offhand before the inventory, so we need to shift by -1
+        return super.getHotbarSlotIndex(index) - 1;
+    }
+
+    @Override
+    public int getOffhandSlotIndex() {
+        return 9;
+    }
+
+    @Override
     public boolean open() {
         if (this.player.isDisconnected() || this.isOpen()) {
             return false;

--- a/src/main/java/eu/pb4/sgui/api/gui/HotbarGui.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/HotbarGui.java
@@ -108,9 +108,9 @@ public class HotbarGui extends BaseSlotGui {
     }
 
     @Override
-    public int getHotbarSlotIndex(int index) {
+    public int getHotbarSlotIndex(int slots, int index) {
         // We add the offhand before the inventory, so we need to shift by -1
-        return super.getHotbarSlotIndex(index) - 1;
+        return super.getHotbarSlotIndex(slots, index) - 1;
     }
 
     @Override

--- a/src/main/java/eu/pb4/sgui/api/gui/SlotGuiInterface.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/SlotGuiInterface.java
@@ -69,11 +69,12 @@ public interface SlotGuiInterface extends SlotHolder, GuiInterface {
     /**
      * Maps a hotbar index into a slot index.
      *
+     * @param slots The number of slots in the screen handler.
      * @param index The hotbar index, this should be [0-8]
      * @return The mapped slot index
      */
-    default int getHotbarSlotIndex(int index) {
-        return this.getSize() + index - 9;
+    default int getHotbarSlotIndex(int slots, int index) {
+        return slots + index - 9;
     }
 
     /**

--- a/src/main/java/eu/pb4/sgui/api/gui/SlotGuiInterface.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/SlotGuiInterface.java
@@ -22,6 +22,7 @@ public interface SlotGuiInterface extends SlotHolder, GuiInterface {
     int getSize();
 
     boolean getLockPlayerInventory();
+
     void setLockPlayerInventory(boolean value);
 
     /**
@@ -62,6 +63,26 @@ public interface SlotGuiInterface extends SlotHolder, GuiInterface {
      */
     default boolean onClick(int index, ClickType type, SlotActionType action, GuiElementInterface element) {
         return false;
+    }
+
+
+    /**
+     * Maps a hotbar index into a slot index.
+     *
+     * @param index The hotbar index, this should be [0-8]
+     * @return The mapped slot index
+     */
+    default int getHotbarSlotIndex(int index) {
+        return this.getSize() + index - 9;
+    }
+
+    /**
+     * Gets the offhand slot index
+     *
+     * @return The offhand slot index
+     */
+    default int getOffhandSlotIndex() {
+        return -1;
     }
 
     @Nullable

--- a/src/main/java/eu/pb4/sgui/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/eu/pb4/sgui/mixin/ServerPlayNetworkHandlerMixin.java
@@ -13,6 +13,7 @@ import eu.pb4.sgui.virtual.hotbar.HotbarScreenHandler;
 import eu.pb4.sgui.virtual.inventory.VirtualScreenHandler;
 import eu.pb4.sgui.virtual.merchant.VirtualMerchantScreenHandler;
 import io.netty.buffer.Unpooled;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.PacketByteBuf;
@@ -81,8 +82,12 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
                         GuiHelpers.sendSlotUpdate(this.player, -1, -1, this.player.currentScreenHandler.getCursorStack(), handler.getRevision());
 
                         if (type.numKey) {
-                            int x = type.value + handler.slots.size() - 10;
-                            GuiHelpers.sendSlotUpdate(player, handler.syncId, x, handler.getSlot(x).getStack(), handler.nextRevision());
+                            int index = handler.getGui().getHotbarSlotIndex(type.value - 1);
+                            GuiHelpers.sendSlotUpdate(this.player, handler.syncId, index, handler.getSlot(index).getStack(), handler.nextRevision());
+                        } else if (type == ClickType.OFFHAND_SWAP) {
+                            int index = handler.getGui().getOffhandSlotIndex();
+                            ItemStack updated = index >= 0 ? handler.getSlot(index).getStack() : ItemStack.EMPTY;
+                            GuiHelpers.sendSlotUpdate(this.player, -2, PlayerInventory.OFF_HAND_SLOT, updated, handler.getRevision());
                         } else if (type == ClickType.MOUSE_DOUBLE_CLICK || type == ClickType.MOUSE_LEFT_SHIFT || type == ClickType.MOUSE_RIGHT_SHIFT || (type.isDragging && type.value == 2)) {
                             GuiHelpers.sendPlayerScreenHandler(this.player);
                         }
@@ -121,8 +126,8 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
     @Inject(method = "onCloseHandledScreen", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/server/world/ServerWorld;)V", shift = At.Shift.AFTER), cancellable = true)
     private void sgui$storeScreenHandler(CloseHandledScreenC2SPacket packet, CallbackInfo info) {
         if (this.player.currentScreenHandler instanceof VirtualScreenHandlerInterface handler) {
-            if (sgui$bookIgnoreClose && this.player.currentScreenHandler instanceof BookScreenHandler) {
-                sgui$bookIgnoreClose = false;
+            if (this.sgui$bookIgnoreClose && this.player.currentScreenHandler instanceof BookScreenHandler) {
+                this.sgui$bookIgnoreClose = false;
                 info.cancel();
                 return;
             }
@@ -177,7 +182,7 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
         }
     }
 
-    @Inject(method = "onCraftRequest", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;updateLastActionTime()V", shift = At.Shift.BEFORE), cancellable = true)
+    @Inject(method = "onCraftRequest", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;updateLastActionTime()V", shift = At.Shift.BEFORE))
     private void sgui$catchRecipeRequests(CraftRequestC2SPacket packet, CallbackInfo ci) {
         if (this.player.currentScreenHandler instanceof VirtualScreenHandler handler && handler.getGui() instanceof SimpleGui gui) {
             try {
@@ -199,7 +204,7 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
                 ci.cancel();
             }
         } catch (Throwable e) {
-            if (this.player.currentScreenHandler instanceof VirtualScreenHandlerInterface handler ) {
+            if (this.player.currentScreenHandler instanceof VirtualScreenHandlerInterface handler) {
                 handler.getGui().handleException(e);
             } else {
                 e.printStackTrace();
@@ -245,28 +250,22 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
 
     @Inject(method = "onPlayerInteractItem", at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/server/world/ServerWorld;)V"), cancellable = true)
     private void sgui$clickWithItem(PlayerInteractItemC2SPacket packet, CallbackInfo ci) {
-        if (this.player.currentScreenHandler instanceof HotbarScreenHandler screenHandler) {
-            var gui = screenHandler.getGui();
-            if (screenHandler.slotsOld != null) {
-                screenHandler.slotsOld.set(gui.getSelectedSlot() + 36, ItemStack.EMPTY);
-                screenHandler.slotsOld.set(45, ItemStack.EMPTY);
-            }
+        if (this.player.currentScreenHandler instanceof HotbarScreenHandler handler) {
+            var gui = handler.getGui();
             gui.onClickItem();
+            handler.syncSelectedSlot();
             ci.cancel();
         }
     }
 
     @Inject(method = "onPlayerInteractBlock", at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/server/world/ServerWorld;)V"), cancellable = true)
     private void sgui$clickOnBlock(PlayerInteractBlockC2SPacket packet, CallbackInfo ci) {
-        if (this.player.currentScreenHandler instanceof HotbarScreenHandler screenHandler) {
-            var gui = screenHandler.getGui();
+        if (this.player.currentScreenHandler instanceof HotbarScreenHandler handler) {
+            var gui = handler.getGui();
 
             if (!gui.onClickBlock(packet.getBlockHitResult())) {
                 var pos = packet.getBlockHitResult().getBlockPos();
-                if (screenHandler.slotsOld != null) {
-                    screenHandler.slotsOld.set(gui.getSelectedSlot() + 36, ItemStack.EMPTY);
-                    screenHandler.slotsOld.set(45, ItemStack.EMPTY);
-                }
+                handler.syncSelectedSlot();
 
                 this.sendPacket(new BlockUpdateS2CPacket(pos, this.player. getServerWorld().getBlockState(pos)));
                 pos = pos.offset(packet.getBlockHitResult().getSide());
@@ -280,15 +279,16 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
 
     @Inject(method = "onPlayerAction", at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/server/world/ServerWorld;)V"), cancellable = true)
     private void sgui$onPlayerAction(PlayerActionC2SPacket packet, CallbackInfo ci) {
-        if (this.player.currentScreenHandler instanceof HotbarScreenHandler screenHandler) {
-            var gui = screenHandler.getGui();
+        if (this.player.currentScreenHandler instanceof HotbarScreenHandler handler) {
+            var gui = handler.getGui();
 
             if (!gui.onPlayerAction(packet.getAction(), packet.getDirection())) {
                 var pos = packet.getPos();
-                if (screenHandler.slotsOld != null) {
-                    screenHandler.slotsOld.set(gui.getSelectedSlot() + 36, ItemStack.EMPTY);
-                    screenHandler.slotsOld.set(45, ItemStack.EMPTY);
+                handler.syncSelectedSlot();
+                if (packet.getAction() == PlayerActionC2SPacket.Action.SWAP_ITEM_WITH_OFFHAND) {
+                    handler.syncOffhandSlot();
                 }
+
                 this.sendPacket(new BlockUpdateS2CPacket(pos, this.player.getServerWorld().getBlockState(pos)));
                 pos = pos.offset(packet.getDirection());
                 this.sendPacket(new BlockUpdateS2CPacket(pos, this.player.getServerWorld().getBlockState(pos)));
@@ -300,8 +300,8 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
 
     @Inject(method = "onPlayerInteractEntity", at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/server/world/ServerWorld;)V"), cancellable = true)
     private void sgui$clickOnEntity(PlayerInteractEntityC2SPacket packet, CallbackInfo ci) {
-        if (this.player.currentScreenHandler instanceof HotbarScreenHandler screenHandler) {
-            var gui = screenHandler.getGui();
+        if (this.player.currentScreenHandler instanceof HotbarScreenHandler handler) {
+            var gui = handler.getGui();
             var buf = new PacketByteBuf(Unpooled.buffer());
             ((PlayerInteractEntityC2SPacketAccessor)packet).invokeWrite(buf);
 
@@ -322,10 +322,7 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
             var isSneaking = buf.readBoolean();
 
             if (!gui.onClickEntity(entityId, type, isSneaking, interactionPos)) {
-                if (screenHandler.slotsOld != null) {
-                    screenHandler.slotsOld.set(gui.getSelectedSlot() + 36, ItemStack.EMPTY);
-                    screenHandler.slotsOld.set(45, ItemStack.EMPTY);
-                }
+                handler.syncSelectedSlot();
                 ci.cancel();
             }
         }
@@ -348,7 +345,7 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
     private void sgui$onCommand(CommandExecutionC2SPacket packet, CallbackInfo ci) {
         if (this.player.currentScreenHandler instanceof BookScreenHandler handler) {
             try {
-                sgui$bookIgnoreClose = true;
+                this.sgui$bookIgnoreClose = true;
                 if (handler.getGui().onCommand("/" + packet.command())) {
                     ci.cancel();
                 }

--- a/src/main/java/eu/pb4/sgui/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/eu/pb4/sgui/mixin/ServerPlayNetworkHandlerMixin.java
@@ -68,6 +68,10 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
                 if (ignore && !handler.getGui().getLockPlayerInventory() && (slot >= handler.getGui().getSize() || slot < 0 || handler.getGui().getSlotRedirect(slot) != null)) {
                     if (type == ClickType.MOUSE_DOUBLE_CLICK || (type.isDragging && type.value == 2)) {
                         GuiHelpers.sendPlayerScreenHandler(this.player);
+                    } else if (type == ClickType.OFFHAND_SWAP) {
+                        int index = handler.getGui().getOffhandSlotIndex();
+                        ItemStack updated = index >= 0 ? handler.getSlot(index).getStack() : ItemStack.EMPTY;
+                        GuiHelpers.sendSlotUpdate(this.player, -2, PlayerInventory.OFF_HAND_SLOT, updated, handler.getRevision());
                     }
 
                     return;
@@ -82,7 +86,7 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
                         GuiHelpers.sendSlotUpdate(this.player, -1, -1, this.player.currentScreenHandler.getCursorStack(), handler.getRevision());
 
                         if (type.numKey) {
-                            int index = handler.getGui().getHotbarSlotIndex(type.value - 1);
+                            int index = handler.getGui().getHotbarSlotIndex(handler.slots.size(), type.value - 1);
                             GuiHelpers.sendSlotUpdate(this.player, handler.syncId, index, handler.getSlot(index).getStack(), handler.nextRevision());
                         } else if (type == ClickType.OFFHAND_SWAP) {
                             int index = handler.getGui().getOffhandSlotIndex();

--- a/src/main/java/eu/pb4/sgui/virtual/hotbar/HotbarScreenHandler.java
+++ b/src/main/java/eu/pb4/sgui/virtual/hotbar/HotbarScreenHandler.java
@@ -10,6 +10,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.collection.DefaultedList;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 public class HotbarScreenHandler extends VirtualScreenHandler {
@@ -75,5 +76,19 @@ public class HotbarScreenHandler extends VirtualScreenHandler {
         } catch (Exception e) {
             this.getGui().handleException(e);
         }
+    }
+
+    @ApiStatus.Internal
+    public void syncSelectedSlot() {
+        var gui = this.getGui();
+        int index = gui.getHotbarSlotIndex(gui.getSelectedSlot());
+        GuiHelpers.sendSlotUpdate(gui.getPlayer(), this.syncId, index, this.getSlot(index).getStack(), this.nextRevision());
+    }
+
+    @ApiStatus.Internal
+    public void syncOffhandSlot() {
+        var gui = this.getGui();
+        int index = gui.getOffhandSlotIndex();
+        GuiHelpers.sendSlotUpdate(gui.getPlayer(), this.syncId, index, this.getSlot(index).getStack(), this.nextRevision());
     }
 }

--- a/src/main/java/eu/pb4/sgui/virtual/hotbar/HotbarScreenHandler.java
+++ b/src/main/java/eu/pb4/sgui/virtual/hotbar/HotbarScreenHandler.java
@@ -81,14 +81,18 @@ public class HotbarScreenHandler extends VirtualScreenHandler {
     @ApiStatus.Internal
     public void syncSelectedSlot() {
         var gui = this.getGui();
-        int index = gui.getHotbarSlotIndex(gui.getSelectedSlot());
-        GuiHelpers.sendSlotUpdate(gui.getPlayer(), this.syncId, index, this.getSlot(index).getStack(), this.nextRevision());
+        if (gui.isOpen()) {
+            int index = gui.getHotbarSlotIndex(this.slots.size(), gui.getSelectedSlot());
+            GuiHelpers.sendSlotUpdate(gui.getPlayer(), this.syncId, index, this.getSlot(index).getStack(), this.nextRevision());
+        }
     }
 
     @ApiStatus.Internal
     public void syncOffhandSlot() {
         var gui = this.getGui();
-        int index = gui.getOffhandSlotIndex();
-        GuiHelpers.sendSlotUpdate(gui.getPlayer(), this.syncId, index, this.getSlot(index).getStack(), this.nextRevision());
+        if (gui.isOpen()) {
+            int index = gui.getOffhandSlotIndex();
+            GuiHelpers.sendSlotUpdate(gui.getPlayer(), this.syncId, index, this.getSlot(index).getStack(), this.nextRevision());
+        }
     }
 }

--- a/src/main/java/eu/pb4/sgui/virtual/inventory/VirtualScreenHandler.java
+++ b/src/main/java/eu/pb4/sgui/virtual/inventory/VirtualScreenHandler.java
@@ -1,5 +1,6 @@
 package eu.pb4.sgui.virtual.inventory;
 
+import eu.pb4.sgui.api.GuiHelpers;
 import eu.pb4.sgui.api.gui.SlotGuiInterface;
 import eu.pb4.sgui.virtual.VirtualScreenHandlerInterface;
 import net.minecraft.entity.player.PlayerEntity;
@@ -59,6 +60,15 @@ public class VirtualScreenHandler extends ScreenHandler implements VirtualScreen
     public void addListener(ScreenHandlerListener listener) {
         super.addListener(listener);
         this.gui.afterOpen();
+    }
+
+    @Override
+    public void syncState() {
+        super.syncState();
+        // We have to manually sync offhand state
+        int index = this.getGui().getOffhandSlotIndex();
+        ItemStack updated = index >= 0 ? this.getSlot(index).getStack() : ItemStack.EMPTY;
+        GuiHelpers.sendSlotUpdate(this.gui.getPlayer(), -2, PlayerInventory.OFF_HAND_SLOT, updated, this.getRevision());
     }
 
     @Override


### PR DESCRIPTION
- Updated dependencies to 1.21.1

- Implemented `getHotbarSlotIndex` and `getOffhandSlotIndex` methods to `SlotGuiInterface`, this allows each gui to define where the hotbar slots and offhand slots are located, this fixes numerous issues with `HotbarGui`s desyncing.
- Fixes other incorrect syncing with `HotbarGui` by sending the correct data to the client instead of modifying the previously sent slots.

- Also fixes an issue where in any non-hotbar gui you could desync items into the offhand, if a player previously had an item in their offhand when a gui opens it will now not display that item.