### PR TITLE
Fix slot redirects not working for spectators

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.21.4-rc1
+minecraft_version=1.21.4-rc3
 yarn_mappings=1.21.4-rc1+build.1
 loader_version=0.16.9
 

--- a/src/main/java/eu/pb4/sgui/api/gui/SlotGuiInterface.java
+++ b/src/main/java/eu/pb4/sgui/api/gui/SlotGuiInterface.java
@@ -6,7 +6,6 @@ import eu.pb4.sgui.api.elements.GuiElementInterface;
 import eu.pb4.sgui.virtual.inventory.VirtualScreenHandler;
 import eu.pb4.sgui.virtual.inventory.VirtualSlot;
 import net.minecraft.item.ItemStack;
-import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.screen.slot.SlotActionType;
 import org.jetbrains.annotations.ApiStatus;
@@ -65,6 +64,14 @@ public interface SlotGuiInterface extends SlotHolder, GuiInterface {
         return false;
     }
 
+    /**
+     * Whether spectators can click on slots.
+     *
+     * @return Returns true if spectators can use this gui.
+     */
+    default boolean canSpectatorsClick() {
+        return true;
+    }
 
     /**
      * Maps a hotbar index into a slot index.

--- a/src/main/java/eu/pb4/sgui/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/eu/pb4/sgui/mixin/ServerPlayNetworkHandlerMixin.java
@@ -1,5 +1,6 @@
 package eu.pb4.sgui.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import eu.pb4.sgui.api.ClickType;
 import eu.pb4.sgui.api.GuiHelpers;
 import eu.pb4.sgui.api.gui.AnvilInputGui;
@@ -62,6 +63,10 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
         if (this.player.currentScreenHandler instanceof VirtualScreenHandler handler) {
             try {
                 var gui = handler.getGui();
+                if (this.player.isSpectator() && !gui.canSpectatorsClick()) {
+                    return;
+                }
+
                 int slot = packet.getSlot();
                 int button = packet.getButton();
 
@@ -98,6 +103,11 @@ public abstract class ServerPlayNetworkHandlerMixin extends ServerCommonNetworkH
         } else if (this.player.currentScreenHandler instanceof BookScreenHandler) {
             ci.cancel();
         }
+    }
+
+    @ModifyExpressionValue(method = "onClickSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;isSpectator()Z"))
+    private boolean sgui$canSpectatorClickSlot(boolean isSpectator) {
+        return isSpectator && !(this.player.currentScreenHandler instanceof VirtualScreenHandler handler && handler.getGui().canSpectatorsClick());
     }
 
     @Inject(method = "onClickSlot", at = @At("TAIL"))


### PR DESCRIPTION
Slot redirects previously didn't work when players were in spectator mode, as vanilla prevents all slot clicks in spectator. I've now added `SlotGuiInterface#canSpectatorsClick` which determines whether spectators can click slots in `SlotGuiInterface`s, by default set to `true`, when set to true all slots are clickable, when in spectator, including redirects, when set to `false` spectators won't be able to click any slots.